### PR TITLE
Make the library reentrant and thread-safe

### DIFF
--- a/OGParser/src/main/java/com/kedia/ogparser/JsoupNetworkCall.kt
+++ b/OGParser/src/main/java/com/kedia/ogparser/JsoupNetworkCall.kt
@@ -4,22 +4,8 @@ import org.jsoup.Jsoup
 
 class JsoupNetworkCall {
 
-    private val REFERRER = "http://www.google.com"
-    private val TIMEOUT = 100000
-    private val DOC_SELECT_QUERY = "meta[property^=og:]"
-    private val OPEN_GRAPH_KEY = "content"
-    private val PROPERTY = "property"
-    private val OG_IMAGE = "og:image"
-    private val OG_DESCRIPTION = "og:description"
-    private val OG_URL = "og:url"
-    private val OG_TITLE = "og:title"
-    private val OG_SITE_NAME = "og:site_name"
-    private val OG_TYPE = "og:type"
-
-    private var openGraphResult: OpenGraphResult? = null
-
     fun callUrl(url: String, agent: String): OpenGraphResult? {
-        openGraphResult = OpenGraphResult()
+        val openGraphResult = OpenGraphResult()
         try {
             val response = Jsoup.connect(url)
                 .ignoreContentType(true)
@@ -30,48 +16,63 @@ class JsoupNetworkCall {
                 .execute()
 
             val doc = response.parse()
-            val ogTags = doc.select(DOC_SELECT_QUERY)
-            when {
-                ogTags.size > 0 ->
-                    ogTags.forEachIndexed { index, _ ->
-                        val tag = ogTags[index]
-                        val text = tag.attr(PROPERTY)
+            val ogTags = doc.select(DOC_SELECT_OGTAGS)
 
-                        when (text) {
-                            OG_IMAGE -> {
-                                openGraphResult!!.image = (tag.attr(OPEN_GRAPH_KEY))
-                            }
-                            OG_DESCRIPTION -> {
-                                openGraphResult!!.description = (tag.attr(OPEN_GRAPH_KEY))
-                            }
-                            OG_URL -> {
-                                openGraphResult!!.url = (tag.attr(OPEN_GRAPH_KEY))
-                            }
-                            OG_TITLE -> {
-                                openGraphResult!!.title = (tag.attr(OPEN_GRAPH_KEY))
-                            }
-                            OG_SITE_NAME -> {
-                                openGraphResult!!.siteName = (tag.attr(OPEN_GRAPH_KEY))
-                            }
-                            OG_TYPE -> {
-                                openGraphResult!!.type = (tag.attr(OPEN_GRAPH_KEY))
-                            }
-                        }
+            ogTags.forEach { tag ->
+                val text = tag.attr(PROPERTY)
+
+                when (text) {
+                    OG_IMAGE -> {
+                        openGraphResult.image = tag.attr(OPEN_GRAPH_KEY)
                     }
+                    OG_DESCRIPTION -> {
+                        openGraphResult.description = tag.attr(OPEN_GRAPH_KEY)
+                    }
+                    OG_URL -> {
+                        openGraphResult.url = tag.attr(OPEN_GRAPH_KEY)
+                    }
+                    OG_TITLE -> {
+                        openGraphResult.title = tag.attr(OPEN_GRAPH_KEY)
+                    }
+                    OG_SITE_NAME -> {
+                        openGraphResult.siteName = tag.attr(OPEN_GRAPH_KEY)
+                    }
+                    OG_TYPE -> {
+                        openGraphResult.type = tag.attr(OPEN_GRAPH_KEY)
+                    }
+                }
             }
 
-            if (openGraphResult!!.title.isNullOrEmpty())
-                openGraphResult!!.title = doc.title()
-            if (openGraphResult!!.description.isNullOrEmpty())
-                openGraphResult!!.description = if (doc.select("meta[name=description]").size != 0) doc.select("meta[name=description]")
-                    .first().attr("content") else ""
-            if (openGraphResult!!.url.isNullOrEmpty())
-                openGraphResult!!.url = getBaseUrl(url)
+            if (openGraphResult.title.isNullOrEmpty()) {
+                openGraphResult.title = doc.title()
+            }
+            if (openGraphResult.description.isNullOrEmpty()) {
+                val docSelection = doc.select(DOC_SELECT_DESCRIPTION)
+                openGraphResult.description = docSelection.firstOrNull()?.attr("content") ?: ""
+            }
+            if (openGraphResult.url.isNullOrEmpty()) {
+                openGraphResult.url = getBaseUrl(url)
+            }
         } catch (e: Exception) {
             e.printStackTrace()
             return null
         }
 
         return openGraphResult
+    }
+
+    companion object {
+        private const val REFERRER = "http://www.google.com"
+        private const val TIMEOUT = 100000
+        private const val DOC_SELECT_OGTAGS = "meta[property^=og:]"
+        private const val DOC_SELECT_DESCRIPTION = "meta[name=description]"
+        private const val OPEN_GRAPH_KEY = "content"
+        private const val PROPERTY = "property"
+        private const val OG_IMAGE = "og:image"
+        private const val OG_DESCRIPTION = "og:description"
+        private const val OG_URL = "og:url"
+        private const val OG_TITLE = "og:title"
+        private const val OG_SITE_NAME = "og:site_name"
+        private const val OG_TYPE = "og:type"
     }
 }

--- a/OGParser/src/main/java/com/kedia/ogparser/OpenGraphCacheProvider.kt
+++ b/OGParser/src/main/java/com/kedia/ogparser/OpenGraphCacheProvider.kt
@@ -9,13 +9,6 @@ class OpenGraphCacheProvider(context: Context) : CacheProvider {
 
     private val pm: SharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
 
-    private val OG_PARSER = "Og_Parser"
-    private val TITLE = OG_PARSER + "_title"
-    private val DESCRIPTION = OG_PARSER + "_description"
-    private val URL = OG_PARSER + "_url"
-    private val IMAGE = OG_PARSER + "_image"
-    private val SITE_NAME = OG_PARSER + "_site_name"
-    private val TYPE = OG_PARSER + "_type"
 
     private fun setTitle(link: String, title: String) {
         pm.edit().putString(TITLE + "_$link", title).apply()
@@ -67,11 +60,11 @@ class OpenGraphCacheProvider(context: Context) : CacheProvider {
 
     private fun urlExists(title: String, description: String, image: String): Boolean {
         return title.isNotEmpty() &&
-                title.equals("null").not() &&
+                title != "null" &&
                 description.isNotEmpty() &&
-                description.equals("null").not() &&
+                title != "null" &&
                 image.isNotEmpty() &&
-                image.equals("null").not()
+                title != "null"
     }
 
     override suspend fun setOpenGraphResult(openGraphResult: OpenGraphResult, url: String) {
@@ -96,5 +89,15 @@ class OpenGraphCacheProvider(context: Context) : CacheProvider {
         val type = getType(url)
         val url = getUrl(url)
         return OpenGraphResult(title, description, url, image, siteName, type)
+    }
+
+    companion object {
+        private const val OG_PARSER = "Og_Parser"
+        private const val TITLE = OG_PARSER + "_title"
+        private const val DESCRIPTION = OG_PARSER + "_description"
+        private const val URL = OG_PARSER + "_url"
+        private const val IMAGE = OG_PARSER + "_image"
+        private const val SITE_NAME = OG_PARSER + "_site_name"
+        private const val TYPE = OG_PARSER + "_type"
     }
 }

--- a/OGParser/src/main/java/com/kedia/ogparser/UtilityFunctions.kt
+++ b/OGParser/src/main/java/com/kedia/ogparser/UtilityFunctions.kt
@@ -4,12 +4,8 @@ import java.net.URI
 import java.net.URL
 
 fun checkNullParserResult(openGraphResult: OpenGraphResult?): Boolean {
-    return (openGraphResult?.title.isNullOrEmpty() ||
-            openGraphResult?.title.equals("null")) &&
-            (openGraphResult?.description.isNullOrEmpty() ||
-                    openGraphResult?.description.equals(
-                        "null"
-                    ))
+    return (openGraphResult?.title.isNullOrEmpty() || openGraphResult?.title == "null") &&
+            (openGraphResult?.description.isNullOrEmpty() || openGraphResult?.description == "null")
 }
 
 fun getBaseUrl(urlString: String): String {


### PR DESCRIPTION
Moves non-immutable variables from class-scope to function scope, and makes the constants shared across all class instances.
This allows to make multiple concurrent calls to `OpenGraphParser.parse` without having different threads and coroutines interfere with each other